### PR TITLE
Create script to fix EoL repos on XO laptops (fixes #3)

### DIFF
--- a/scripts/xo-eol-repos/f18/fedora-updates.repo
+++ b/scripts/xo-eol-repos/f18/fedora-updates.repo
@@ -1,0 +1,29 @@
+[updates]
+name=Fedora $releasever - $basearch - Updates
+failovermethod=priority
+baseurl=https://archives.fedoraproject.org/pub/archive/fedora/linux/updates/$releasever/$basearch/
+enabled=1
+gpgcheck=1
+metadata_expire=6h
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch
+skip_if_unavailable=False
+
+[updates-debuginfo]
+name=Fedora $releasever - $basearch - Updates - Debug
+failovermethod=priority
+baseurl=https://archives.fedoraproject.org/pub/archive/fedora/linux/updates/$releasever/$basearch/debug/
+enabled=0
+gpgcheck=1
+metadata_expire=6h
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch
+skip_if_unavailable=False
+
+[updates-source]
+name=Fedora $releasever - Updates Source
+failovermethod=priority
+baseurl=https://archives.fedoraproject.org/pub/archive/fedora/linux/updates/$releasever/SRPMS/
+enabled=0
+gpgcheck=1
+metadata_expire=6h
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch
+skip_if_unavailable=False

--- a/scripts/xo-eol-repos/f18/fedora.repo
+++ b/scripts/xo-eol-repos/f18/fedora.repo
@@ -1,0 +1,29 @@
+[fedora]
+name=Fedora $releasever - $basearch
+failovermethod=priority
+baseurl=https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/$releasever/Everything/$basearch/os/
+enabled=1
+metadata_expire=28d
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch
+skip_if_unavailable=False
+
+[fedora-debuginfo]
+name=Fedora $releasever - $basearch - Debug
+failovermethod=priority
+baseurl=https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/$releasever/Everything/$basearch/debug/
+enabled=0
+metadata_expire=28d
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch
+skip_if_unavailable=False
+
+[fedora-source]
+name=Fedora $releasever - Source
+failovermethod=priority
+baseurl=https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/$releasever/Everything/source/SRPMS/
+enabled=0
+metadata_expire=28d
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch
+skip_if_unavailable=False

--- a/scripts/xo-eol-repos/f18/fix_repos.sh
+++ b/scripts/xo-eol-repos/f18/fix_repos.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+#
+# Author:   Justin W. Flory <me [at] justinwflory [dot] com>
+# Language: Shell
+# Filename: fix_repos.sh
+#
+# Description:
+#    Automatically fixes the One Laptop per Child (OLPC)
+#    XO laptops to use correct repository files for its
+#    version of Fedora. For the HFOSS course at the
+#    Rochester Institute of Technology, most of the XOs
+#    are running Fedora 18. This script targets setting
+#    up the EoL (end-of-life) repos for the sake of the
+#    laptop.
+#
+# License:
+#    This Source Code Form is subject to the terms of the Mozilla Public
+#    License, v. 2.0. If a copy of the MPL was not distributed with this
+#    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+
+# Bash configuration
+set -euxo pipefail
+
+# Environment variables
+KEYSIGN_DIR="/etc/pki/rpm-gpg"
+YUM_REPOS_DIR="/etc/yum.repos.d"
+
+# Make our working space
+if [ ! -d "$TMPDIR" ]; then
+	echo "Working directory does not exist, making temporary directory..."
+	mkdir $TMPDIR
+fi
+cd $TMPDIR
+
+# Pull down obsolete keys for Fedora 18 and import
+#     https://getfedora.org/keys/obsolete.html
+#     https://getfedora.org/keys/faq/
+curl -L -O https://getfedora.org/static/DE7F38BD.txt
+curl -L -O https://getfedora.org/static/A4D647E9.txt
+sudo rpm --import DE7F38BD.txt && rm DE7F38BD.txt
+sudo rpm --import A4D647E9.txt && rm A4D647E9.txt
+
+# Get the new repo files and replace the old ones
+curl -L -O https://mirror.justinwflory.com/pub/linux/fedora/eol-repos/fedora.repo
+curl -L -O https://mirror.justinwflory.com/pub/linux/fedora/eol-repos/fedora-updates.repo
+
+if [ -d $YUM_REPOS_DIR/fedora.repo ]; then
+	sudo rm $YUM_REPOS_DIR/fedora.repo
+fi
+if [ -d $YUM_REPOS_DIR/fedora-updates.repo ]; then
+	sudo rm $YUM_REPOS_DIR/fedora-updates.repo
+fi
+
+sudo mv fedora.repo $YUM_REPOS_DIR
+sudo mv fedora-updates.repo $YUM_REPOS_DIR
+
+# Clean up, print out
+if [ "$(ls -A $TMPDIR)" ]; then
+	echo "Directory is not empty. Leaving."
+else
+	rmdir $TMPDIR
+fi
+
+echo "Your repos should be fixed! Try 'sudo yum install git' to try it out."


### PR DESCRIPTION
This pull request attempts to fix issue #3.
# What it does

The script pulls down the GPG public keys used for Fedora 18 package signing. It imports those keys into the system. Afterwards, it pulls down the repo files that have the correct `baseurl`, deletes the old files, and replaces them with the new.

After doing this, the XO user should be able to use `yum` once again.
# Why it matters

This will allow students to interact with `yum` in the command line on the XO to install software. At the beginning of my HFOSS course, my XO laptop was a freshly flashed system. Because of this, the repo files in the system were made to point to the URLs used if Fedora 18 were still a supported release. However, that is not the case. F18 hit EoL status many years ago. This script just adjusts the system to use the accurate GPG keys and repo `baseurl` so it will work once again.
# Note: Code review

A few things to note:
- This is my first "real" bash script I've written, so I'd like feedback on syntax or "good behavior" vs. "bad behavior"
- I no longer have an XO laptop to test this script on, making it hard to verify that it works

Having someone else review my basic script would be useful. This is probably relevant for @ritjoe in teaching future versions of the course. If @Nolski or @brendan-w wanted to proof my bash script, that would be nice too.

Cheers, and thanks.
