### PR TITLE
Integrate all roles together for full deployment

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,6 +3,7 @@
 
 Vagrant.configure("2") do |config|
   config.vm.box = "centos/7"
+  config.vm.network "forwarded_port", guest: 80, host: 8080
   config.vm.provider :libvirt do |libvirt|
     libvirt.cpus = 2
     libvirt.memory = 4096

--- a/roles/mariadb/templates/my.cnf.j2
+++ b/roles/mariadb/templates/my.cnf.j2
@@ -6,5 +6,5 @@ user=mysql
 symbolic-links=0
 
 [mysqld_safe]
-log-error=/var/log/mysqld.log
-pid-file=/var/run/mariadb/mysqld.pid
+log-error=/var/log/mariadb/mariadb.log
+pid-file=/var/run/mariadb/mariadb.pid

--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -4,11 +4,22 @@
     name: nginx
     state: present
 
+- name: create directory for global configurations
+  file:
+    state: directory
+    path: /etc/nginx/global
+
+- name: copy global nginx configurations
+  template: src={{ item }} dest=/etc/nginx/global/{{ item }}
+  notify: restart nginx
+  with_items:
+    - restrictions.conf
+    - wordpress.conf
+
 - name: copy WordPress nginx configuration
   template:
-    src: wordpress.conf
-    dest: /etc/nginx/conf.d/wordpress.conf
-  notify: restart nginx
+    src: fossrit.jwf.io.conf
+    dest: /etc/nginx/conf.d/fossrit.jwf.io.conf
 
 - name: insert firewalld rule for nginx
   firewalld:

--- a/roles/nginx/templates/fossrit.jwf.io.conf
+++ b/roles/nginx/templates/fossrit.jwf.io.conf
@@ -1,0 +1,25 @@
+# Redirect everything to the main site. We use a separate server statement and NOT an if statement.
+# See: http://wiki.nginx.org/IfIsEvil
+# https://codex.wordpress.org/Nginx
+
+
+# Upstream to abstract backend connection(s) for php
+upstream php {
+    server          unix:/var/run/php-fpm/wordpress.sock;
+    server          127.0.0.1:9000;
+}
+
+
+server {
+    server_name     _;
+    return          302 $scheme://fossrit.jwf.io$request_uri;
+}
+
+
+server {
+    server_name     fossrit.jwf.io;
+    root            /var/www/wordpress;
+
+    include         global/restrictions.conf;
+    include         global/wordpress.conf;
+}

--- a/roles/nginx/templates/restrictions.conf
+++ b/roles/nginx/templates/restrictions.conf
@@ -1,0 +1,23 @@
+# Global restrictions configuration file.
+# https://codex.wordpress.org/Nginx
+# Designed to be included in any server {} block.
+
+
+location = /favicon.ico {
+    log_not_found off;
+    access_log off;
+}
+
+
+location = /robots.txt {
+    allow all;
+    log_not_found off;
+    access_log off;
+}
+
+
+# Deny all attempts to access hidden files such as .htaccess, .htpasswd, .DS_Store (Mac).
+# Keep logging the requests to parse later (or to pass to firewall utilities such as fail2ban)
+location ~ /\. {
+    deny all;
+}

--- a/roles/nginx/templates/wordpress.conf
+++ b/roles/nginx/templates/wordpress.conf
@@ -1,31 +1,44 @@
-server {
-    listen       443 default_server;
-    server_name  fossrit.jwf.io;
-    root         /var/www/wordpress/;
+# WordPress single site rules.
+# https://www.nginx.com/resources/wiki/start/topics/recipes/wordpress/
+# Designed to be included in any server {} block.
 
-	client_max_body_size 64M;
- 
-	# Deny access to any files with a .php extension in the uploads directory
-    location ~* /(?:uploads|files)/.*\.php$ {
-        deny all;
-    }
+index index.php;
 
-    location / {
-        index     index.php index.html index.htm;
-        try_files $uri $uri/ /index.php?$args;
-    }
 
-    location ~* \.(gif|jpg|jpeg|png|css|js)$ {
-        expires max;
-    }
+location / {
+    # This is cool because no php is touched for static content.
+    # include the "?$args" part so non-default permalinks don't break with query string
+    try_files $uri $uri/ /index.php?$args;
+}
 
-    location ~ \.php$ {
-        try_files               $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_index           index.php;
-        fastcgi_pass            unix:/var/run/php-fpm/wordpress.sock;
-        fastcgi_param           SCRIPT_FILENAME
-                                $document_root$fastcgi_script_name;
-        include                 fastcgi_params;
-    }
+
+location ~ \.php$ {
+    #NOTE: You should have "cgi.fix_pathinfo = 0;" in php.ini
+    include                  fastcgi_params;
+    try_files                $uri =404;
+    fastcgi_split_path_info  ^(.+\.php)(/.+)$;
+    fastcgi_index            index.php;
+    fastcgi_param            SCRIPT_FILENAME $document_root$fastcgi_script_name;
+    fastcgi_intercept_errors on;
+    fastcgi_pass php;
+}
+
+
+location ~* \.(js|css|png|jpg|jpeg|gif|ico)$ {
+    expires         max;
+    log_not_found   off;
+}
+
+
+# Deny access to any files with a .php extension in the uploads directory for the single site
+location ~ ^/wp-content/uploads/.*\.php$ {
+    deny all;
+}
+
+
+# Deny access to any files with a .php extension in the uploads directory
+# Works in sub-directory installs and also in multisite network
+# Keep logging the requests to parse later (or to pass to firewall utilities such as fail2ban)
+location ~* /(?:uploads|files)/.*\.php$ {
+    deny all;
 }

--- a/roles/php-fpm/templates/wordpress.conf
+++ b/roles/php-fpm/templates/wordpress.conf
@@ -11,5 +11,5 @@ pm.start_servers = 1
 pm.min_spare_servers = 1
 pm.max_spare_servers = 3
 pm.max_requests = 500
-chdir = /var/www/wordpress/
-php_admin_value[open_basedir] = /var/www/wordpress/:/tmp
+chdir = /var/www/wordpress
+php_admin_value[open_basedir] = /var/www/wordpress:/tmp


### PR DESCRIPTION
_Optionally tagging @nlMeminger, @ct-martin, and @ritjoe for review._

---

This commit brings all existing roles together and integrates them. It
makes it possible for someone to use these roles in conjunction with
each other, such as for a server configuration. It allows us to move
forward with running it on our infrastructure.

A summation of changes:

MariaDB
-------

* Copy defaults from current MariaDB configuration

php-fpm
-------

* Minor syntax cleanup

nginx
-----

* Split configurations out into three different globs
  * **restrictions.conf**: Base set of restrictions for all sites
  * **wordpress.conf**: Base set of guidelines for any WordPress site
  * **fossrit.jwf.io**: Single installed WordPress site
* Adjust various settings with PHP

Ansible
-------

* Update nginx role task to load in new global config files

Resources
---------

Resources informing this commit:

* https://codex.wordpress.org/Nginx
* https://www.nginx.com/resources/wiki/start/topics/recipes/wordpress/