### PR TITLE
Add CI tests with Travis CI (closes #11)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: python
+python: "3.6"
+install: "pip install yamllint"
+script: "yamllint -c .yamllint ."
+
+notifications:
+  irc: "ircs://chat.freenode.net:6697/#rit-foss-admin"

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,4 @@
+extends: relaxed
+
+rules:
+  line-length: disable

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ FOSS@MAGIC infrastructure
 =========================
 
 [![License: MPL 2.0](https://img.shields.io/badge/License-MPL%202.0-brightgreen.svg)](https://opensource.org/licenses/MPL-2.0)
+[![Build Status](https://travis-ci.org/FOSSRIT/infrastructure.svg?branch=master)](https://travis-ci.org/FOSSRIT/infrastructure)
 
 Set of scripts, playbooks, and other tools to automate and manage FOSS@MAGIC infrastructure
 

--- a/roles/sshd/tasks/main.yml
+++ b/roles/sshd/tasks/main.yml
@@ -14,7 +14,7 @@
   loop: "{{ authorized_users|dict2items }}"
 
 - name: add SSH public keys for authorized users (~/.ssh/authorized_keys)
-  template: 
+  template:
     src: authorized_keys
     dest: "{{ item.value.home_dir }}/.ssh/authorized_keys"
     owner: "{{ item.key }}"
@@ -23,7 +23,7 @@
   loop: "{{ authorized_users|dict2items }}"
 
 - name: configure SSH server (/etc/ssh/sshd_config)
-  template: 
+  template:
     src: sshd_config
     dest: "/etc/ssh/sshd_config"
   notify: restart sshd


### PR DESCRIPTION
This PR closes #11 by adding basic YAML lint tests to new pull requests. It uses the `yamllint` Python package and a custom config. Travis CI is utilized for the tests. Build notifications are sent to `#rit-foss-admin` IRC channel on Freenode.