### PR TITLE
[matterbridge] add app-specific playbook for faster runs after changes

### DIFF
--- a/playbooks/apps/matterbridge.yml
+++ b/playbooks/apps/matterbridge.yml
@@ -1,0 +1,7 @@
+---
+- name: synchronize matterbridge deployment state to irc-lug.rit.edu
+  hosts: irc-lug.rit.edu
+  become: yes
+
+  roles:
+    - matterbridge


### PR DESCRIPTION
This pull request adds a playbook for the `matterbridge` role. It shortens run time for playbook re-runs. It's intended for pushing minor changes instead of running an entire host's playbook.