### PR TITLE
matterbridge: Update to v1.15.0, update distribution URLs

### DIFF
--- a/roles/matterbridge/tasks/main.yml
+++ b/roles/matterbridge/tasks/main.yml
@@ -33,8 +33,8 @@
 # Manually retrieve a sha512sum hash for a new release when updating this task.
 - name: download matterbridge binary
   get_url:
-    url: https://github.com/42wim/matterbridge/releases/download/{{ matterbridge_config.version }}/matterbridge-linux-amd64
-    checksum: "sha512:{{ matterbridge_config.binary_sha512sum }}"
+    url: "https://github.com/42wim/matterbridge/releases/download/v{{ matterbridge_config.version }}/matterbridge-{{ matterbridge_config.version }}-linux-64bit"
+    checksum: "sha256:{{ matterbridge_config.binary_checksum }}"
     backup: yes
     dest: /usr/local/bin/matterbridge
     mode: 0755

--- a/roles/matterbridge/vars/main.yml
+++ b/roles/matterbridge/vars/main.yml
@@ -9,8 +9,8 @@ default_slack_ignore_nicks: ""
 default_slack_team_name: rit-lug
 
 matterbridge_config:
-  binary_sha512sum: 50682f99de593b1f0da4dcd25f4197893901bcbf0d78052b6b3bbbc7af5295bfb00e7dc0a7bc36eb8aa40dd51da036f91069161ace572b97c1021668866d47a5
-  version: v1.12.2
+  binary_checksum: a86b4ad887092496da2af0be0abb7e3d5d4aaa87239434eccf72da91601c7a52
+  version: 1.15.0
 
   rit:
     irc:


### PR DESCRIPTION
This commit changes the following:

* Updates Matterbridge to latest upstream version, v1.15.0
* Changes distribution method to follow latest format by upstream

The v1.15.0 upgrade includes a bugfix from v1.14.2 that affected the IRC
bridge. In previous versions, the bot would not reconnect automatically
or gracefully if it lost connection to the IRC server. Now, the bot
should automatically reconnect if the connection is terminated or broken
for some reason. cc: @Tjzabel @ct-martin

Additionally, upstream also ships releases in a new format. I changed
the URL schema to match the new format and changed the checksums to
sha256sum since upstream provides those in a release. Previously, I was
calculating sha512sums manually, which isn't exactly straightforward.

---

This change was tested and is currently deployed in production.