### PR TITLE
matterbridge: Upgrade to latest v1.15.1 upstream

### DIFF
--- a/roles/matterbridge/vars/main.yml
+++ b/roles/matterbridge/vars/main.yml
@@ -10,7 +10,7 @@ default_slack_team_name: rit-lug
 
 matterbridge_config:
   binary_checksum: a86b4ad887092496da2af0be0abb7e3d5d4aaa87239434eccf72da91601c7a52
-  version: 1.15.0
+  version: 1.15.1
 
   rit:
     irc:


### PR DESCRIPTION
No breaking changes I see that should affect us, but another set of eyes
are always welcome:

https://github.com/42wim/matterbridge/releases/tag/v1.15.1

Signed-off-by: Justin W. Flory <git@jwf.io>