### PR TITLE
Make #rit-foss use HEAD for TeleIRC.

### DIFF
--- a/roles/jwflory.teleirc/vars/main.yml
+++ b/roles/jwflory.teleirc/vars/main.yml
@@ -46,7 +46,7 @@ bots:
     teleirc_token: "{{ vault_bots.rit_foss.vault_teleirc_token }}"
     teleirc_chat_id: "{{ vault_bots.rit_foss.vault_teleirc_chat_id }}"
     imgur_client_id: "{{ default_imgur_client_id }}"
-    version: "{{ default_version }}"
+    version: HEAD
 
   rit_foss_admin:
     cn: "rit-foss-admin"


### PR DESCRIPTION
This is a super simple PR, but may have implications.

This PR makes the `#rit-foss` IRC channel use TeleIRC's latest HEAD. In order to get a better feel of how TeleIRC is working before a release, I would like to make use of `#rit-foss`'s extra user traffic in order to pin down issues sooner. 