### PR TITLE
teleirc: Version bump to v1.3.2

### DIFF
--- a/roles/jwflory.teleirc/vars/main.yml
+++ b/roles/jwflory.teleirc/vars/main.yml
@@ -6,7 +6,7 @@ authorized_users:
 default_imgur_client_id: "{{ vault_default_imgur_client_id }}"
 default_irc_server: chat.freenode.net
 default_irc_nickserv_service: NickServ
-default_version: v1.3.1
+default_version: v1.3.2
 
 bots:
   minecon_agents:
@@ -46,7 +46,7 @@ bots:
     teleirc_token: "{{ vault_bots.rit_foss.vault_teleirc_token }}"
     teleirc_chat_id: "{{ vault_bots.rit_foss.vault_teleirc_chat_id }}"
     imgur_client_id: "{{ default_imgur_client_id }}"
-    version: HEAD
+    version: "{{ default_version }}"
 
   rit_foss_admin:
     cn: "rit-foss-admin"


### PR DESCRIPTION
Brings us to the latest upstream release. Fixes HTML rendering in messages.