### PR TITLE
matterbridge: Upgrade to latest upstream, v1.16.0

### DIFF
--- a/roles/matterbridge/vars/main.yml
+++ b/roles/matterbridge/vars/main.yml
@@ -10,7 +10,7 @@ default_slack_team_name: rit-lug
 
 matterbridge_config:
   binary_checksum: a86b4ad887092496da2af0be0abb7e3d5d4aaa87239434eccf72da91601c7a52
-  version: 1.15.1
+  version: 1.16.0
 
   rit:
     irc:


### PR DESCRIPTION
This brings us to the latest upstream version of matterbridge. Nothing
new in this release for the IRC or Slack bridges, but it does update
some dependencies.

I haven't ran this yet. I'll run the playbook after it merges to `master`.