### PR TITLE
matterbridge: Update to v1.16.1

### DIFF
--- a/roles/matterbridge/vars/main.yml
+++ b/roles/matterbridge/vars/main.yml
@@ -9,8 +9,8 @@ default_slack_ignore_nicks: ""
 default_slack_team_name: rit-lug
 
 matterbridge_config:
-  binary_checksum: "f9301cd86750814f4fa171c81581524e1d72f49e0b7307d72691787b17ddeaab"
-  version: 1.16.0
+  binary_checksum: "2d8e015ff8e17da9e1aee6b7d76d8ad79b2a9d01112242046d1c9a8b942f9a15"
+  version: 1.16.1
 
   rit:
     irc:


### PR DESCRIPTION
Matterbridge upstream cut a new release of Matterbridge with some fixes
for various Slack-related bugs. See the full changelog for more details:

https://github.com/42wim/matterbridge/releases/tag/v1.16.1