### PR TITLE
docs: Add explainer on how to upgrade Matterbridge

### DIFF
--- a/docs/upgrade-matterbridge.adoc
+++ b/docs/upgrade-matterbridge.adoc
@@ -1,0 +1,41 @@
+= How to upgrade the FOSSRIT Matterbridge
+
+This document explains how to upgrade the Matterbridge bot to a new upstream release.
+
+
+== Required files
+
+Matterbridge upgrades are managed via variables in the `matterbridge` role:
+
+* `roles/matterbridge/vars/main.yml`
+
+
+== Update version and checksum
+
+The relevant variables are below:
+
+.roles/matterbridge/vars/main.yml
+[source,yaml]
+----
+matterbridge_config:
+  binary_checksum: "f030cae539278c8e3cf6d73d69ed8a11885aec83c73ebf6c2bd7123f14cea974"
+  version: 1.16.2
+----
+
+* `binary_checksum`: Checksum value https://github.com/42wim/matterbridge/releases[provided in upstream releases]
+* `version`: String of version number; should NOT include a `v` character
+
+Update the version and checksum to the values for the new release.
+
+
+== Run playbook
+
+Re-run any playbook using the Matterbridge role.
+Matterbridge will be upgraded in the next playbook run.
+
+Example command:
+
+[source,sh]
+----
+ansible-playbook -K -t matterbridge playbooks/irc-lug.yml
+----


### PR DESCRIPTION
I haven't documented what this process is and it is an essential part of
RIT FOSS infrastructure. This attempts to explain the upgrade process
for Matterbridge as I have been doing it for the last year.

![Screenshot of Markdown-rendered page for upgrading Matterbridge](https://user-images.githubusercontent.com/4721034/69341789-3976a480-0c38-11ea-91b8-e4662e3d3727.png "Screenshot of Markdown-rendered page for upgrading Matterbridge")