### PR TITLE
Add metrics host to inventory

### DIFF
--- a/inventory/inventory
+++ b/inventory/inventory
@@ -1,3 +1,9 @@
+[metrics]
+foss-dashboard.rit.edu
+
+[metrics:vars]
+ansible_user=jwf9260
+
 [discourse]
 fossrit.community ansible_python_interpreter=/usr/bin/python3
 
@@ -7,3 +13,6 @@ estrella.justinwflory.com
 [centos7]
 estrella.justinwflory.com
 irc-lug.rit.edu
+
+[ubuntu]
+foss-dashboard.rit.edu

--- a/playbooks/metrics.yml
+++ b/playbooks/metrics.yml
@@ -1,0 +1,7 @@
+---
+- name: synchronize GrimoireLabs host
+  hosts: metrics
+  become: yes
+
+  roles:
+    - { role: base/ubuntu-18.04-lts, tags: ["base", "ubuntu"] }

--- a/roles/base/ubuntu-18.04-lts/tasks/main.yml
+++ b/roles/base/ubuntu-18.04-lts/tasks/main.yml
@@ -1,0 +1,12 @@
+---
+- name: install base packages
+  apt:
+    state: present
+    name:
+      - certbot
+      - git
+      - htop
+      - python3
+      - python3-pip
+    autoclean: yes
+    update_cache: yes


### PR DESCRIPTION
This commit adds the College of Art and Design virtual machine in
Institute Hall to the Ansible inventory. Along with it, I added a new
base role for an Ubuntu 18.04 LTS machine, since this is the operating
system that the CAD admins use as a base. Additionally, I also added a
new playbook to run the role on the host. I tested this locally before
committing and verified it all works.

Currently, I'm hard-coding my RIT computer account as the login user,
which obviously is a hard block on me. A future next step is to set up
an Ansible system user for running playbooks. I need to think about this
harder before implementing, but in the meanwhile, this commit gets us
rolling.

cc: @Nolski @Tjzabel