### PR TITLE
teleirc: Upgrade v1.3.2 -> v1.3.3

### DIFF
--- a/roles/jwflory.teleirc/vars/main.yml
+++ b/roles/jwflory.teleirc/vars/main.yml
@@ -6,7 +6,7 @@ authorized_users:
 default_imgur_client_id: "{{ vault_default_imgur_client_id }}"
 default_irc_server: chat.freenode.net
 default_irc_nickserv_service: NickServ
-default_version: v1.3.2
+default_version: v1.3.3
 
 bots:
   minecon_agents:


### PR DESCRIPTION
This brings our deployed version of TeleIRC to the latest supported
upstream release.