### PR TITLE
matterbridge: Join #rit-python + #python

### DIFF
--- a/roles/matterbridge/templates/matterbridge.toml
+++ b/roles/matterbridge/templates/matterbridge.toml
@@ -194,6 +194,18 @@ enable=true
     channel="{{ matterbridge_config.rit_lug_sysadmin.slack.channel }}"
 
 [[gateway]]
+name="gateway_rit_python"
+enable=true
+
+    [[gateway.inout]]
+    account="irc.{{ default_irc_network_name }}"
+    channel="{{ matterbridge_config.rit_python.irc.channel }}"
+
+    [[gateway.inout]]
+    account="slack.{{ default_slack_team_name }}"
+    channel="{{ matterbridge_config.rit_python.slack.channel }}"
+
+[[gateway]]
 name="gateway_rit_tigeros"
 enable=true
 

--- a/roles/matterbridge/vars/main.yml
+++ b/roles/matterbridge/vars/main.yml
@@ -40,6 +40,13 @@ matterbridge_config:
     slack:
       channel: sysadmin
 
+  rit_python:
+    irc:
+      bot_name: mb-ritpy
+      channel: "#rit-python"
+    slack:
+      channel: python
+
   rit_tigeros:
     irc:
       bot_name: mb-tigeros


### PR DESCRIPTION
This commit changes the Matterbridge role to add a new bridge to the
`#python` Slack channel and the `#rit-python` IRC channel.