### PR TITLE
matterbridge: Upgrade v1.16.2 -> v1.16.3

### DIFF
--- a/roles/matterbridge/vars/main.yml
+++ b/roles/matterbridge/vars/main.yml
@@ -9,8 +9,8 @@ default_slack_ignore_nicks: ""
 default_slack_team_name: rit-lug
 
 matterbridge_config:
-  binary_checksum: "f030cae539278c8e3cf6d73d69ed8a11885aec83c73ebf6c2bd7123f14cea974"
-  version: 1.16.2
+  binary_checksum: "46a85de97e44fe36cc5379566955ac89b632d3138e61ea4aeef216d77187cce9"
+  version: 1.16.3
 
   rit:
     irc:


### PR DESCRIPTION
This bumps us to the newest release of Matterbridge, v1.16.3, released
by @42wim. Most notably, this includes a bug fix for the Slack bridge
and rate-limiting, something we noticed on our side at some point in the
last month.

https://github.com/42wim/matterbridge/pull/959

CC: @thenaterhood @Tjzabel @Nolski… anyone else that noticed this…