### PR TITLE
matterbridge: Unify IRC channels to RIT namespace

### DIFF
--- a/roles/matterbridge/templates/matterbridge.toml
+++ b/roles/matterbridge/templates/matterbridge.toml
@@ -229,6 +229,10 @@ enable=true
     account="slack.{{ default_slack_team_name }}"
     channel="{{ matterbridge_config.ritlug.slack.channel }}"
 
+    [[gateway.inout]]
+    account="irc.{{ default_irc_network_name }}"
+    channel="#ritlug"
+
 [[gateway]]
 name="gateway_ritlug_teleirc"
 enable=true
@@ -240,3 +244,7 @@ enable=true
     [[gateway.inout]]
     account="slack.{{ default_slack_team_name }}"
     channel="{{ matterbridge_config.ritlug_teleirc.slack.channel }}"
+
+    [[gateway.inout]]
+    account="irc.{{ default_irc_network_name }}"
+    channel="#ritlug-teleirc"

--- a/roles/matterbridge/vars/main.yml
+++ b/roles/matterbridge/vars/main.yml
@@ -57,13 +57,13 @@ matterbridge_config:
   ritlug:
     irc:
       bot_name: mb-ritlug
-      channel: "#ritlug"
+      channel: "#rit-lug"
     slack:
       channel: general
 
   ritlug_teleirc:
     irc:
       bot_name: mb-teleirc
-      channel: "#ritlug-teleirc"
+      channel: "#rit-lug-teleirc"
     slack:
       channel: teleirc


### PR DESCRIPTION
This commit reorganizes the channels used for the `#ritlug`/`#general`
channel and the `#ritlug-teleirc`/`#teleirc` channels. This change is
done because RIT/FOSS@MAGIC is registered to the `#rit-*` namespace. Any
channels that fall underneath the umbrella of the `#rit-*` namespace
enable Freenode operators to provide support to organization admins to
troubleshoot or change permissions in channels. This also allows us to
follow a better categorization system for channels, e.g. FOSS@MAGIC
admins control `#rit-*` channels, but RITlug eboard controls
`#rit-lug-*` channels. Just an example!

The commit does exactly the following:

1. Renames vars file channels to use RIT namespace format
2. Adds temporary manual entry in matterbridge config to route traffic
   into `#ritlug` and `#ritlug-teleirc`, before officially deprecating

I'm not sure how option 2 will work but it will be a cool experiment to see
what happens, since we have RITlug/teleirc as a middleware of sorts
here.