### PR TITLE
teleirc: Adjust IRC channel names (#ritlug* -> #rit-lug*)

### DIFF
--- a/playbooks/manual/purge_teleirc_ritlug_bots.yml
+++ b/playbooks/manual/purge_teleirc_ritlug_bots.yml
@@ -1,0 +1,30 @@
+---
+- name: purge old TeleIRC bots from Freenode IRC channel changes
+  hosts: irc-lug.rit.edu
+  become: yes
+
+  tasks:
+    - name: stop systemd services for old bots
+      service:
+        name: "{{ item }}"
+        state: stopped
+        enabled: no
+      loop:
+        - teleirc-ritlug.service
+        - teleirc-ritlug-teleirc.service
+
+    - name: purge old bot directories
+      file:
+        path: "/usr/lib64/teleirc/{{ item }}"
+        state: absent
+      loop:
+        - ritlug
+        - ritlug-teleirc
+
+    - name: delete systemd service files
+      file:
+        path: "/usr/lib/systemd/system/{{ item }}"
+        state: absent
+      loop:
+        - teleirc-ritlug.service
+        - teleirc-ritlug-teleirc.service

--- a/roles/jwflory.teleirc/vars/main.yml
+++ b/roles/jwflory.teleirc/vars/main.yml
@@ -100,29 +100,29 @@ bots:
     imgur_client_id: "{{ default_imgur_client_id }}"
     version: "{{ default_version }}"
 
-  ritlug:
-    cn: "ritlug"
+  rit_lug:
+    cn: "rit-lug"
     irc_blacklist: "CowSayBot"
     irc_bot_name: tg-ritlug
-    irc_channel: "#ritlug"
+    irc_channel: "#rit-lug"
     irc_server: "{{ default_irc_server }}"
     irc_nickserv_service: "{{ default_irc_nickserv_service }}"
-    irc_nickserv_password: "{{ vault_bots.ritlug.vault_irc_nickserv_password }}"
-    teleirc_token: "{{ vault_bots.ritlug.vault_teleirc_token }}"
-    teleirc_chat_id: "{{ vault_bots.ritlug.vault_teleirc_chat_id }}"
+    irc_nickserv_password: "{{ vault_bots.rit_lug.vault_irc_nickserv_password }}"
+    teleirc_token: "{{ vault_bots.rit_lug.vault_teleirc_token }}"
+    teleirc_chat_id: "{{ vault_bots.rit_lug.vault_teleirc_chat_id }}"
     imgur_client_id: "{{ default_imgur_client_id }}"
     version: "{{ default_version }}"
 
-  ritlug_teleirc:
-    cn: "ritlug-teleirc"
+  rit_lug_teleirc:
+    cn: "rit-lug-teleirc"
     irc_blacklist: ""
     irc_bot_name: tg-teleirc
-    irc_channel: "#ritlug-teleirc"
+    irc_channel: "#rit-lug-teleirc"
     irc_server: "{{ default_irc_server }}"
     irc_nickserv_service: "{{ default_irc_nickserv_service }}"
-    irc_nickserv_password: "{{ vault_bots.ritlug_teleirc.vault_irc_nickserv_password }}"
-    teleirc_token: "{{ vault_bots.ritlug_teleirc.vault_teleirc_token }}"
-    teleirc_chat_id: "{{ vault_bots.ritlug_teleirc.vault_teleirc_chat_id }}"
+    irc_nickserv_password: "{{ vault_bots.rit_lug_teleirc.vault_irc_nickserv_password }}"
+    teleirc_token: "{{ vault_bots.rit_lug_teleirc.vault_teleirc_token }}"
+    teleirc_chat_id: "{{ vault_bots.rit_lug_teleirc.vault_teleirc_chat_id }}"
     imgur_client_id: "{{ default_imgur_client_id }}"
     version: HEAD
 


### PR DESCRIPTION
Recently, the `#ritlug*` IRC channels were moved to the `#rit-lug*`
namespace. This was done to bring the channels under the Freenode
project registration we have for the `#rit-*` channels. This grants us
more control over what happens in these channels, as they are tied to
our Freenode project registration.