### PR TITLE
matterbridge: Deprecate #ritlug/#ritlug-teleirc IRC channels

### DIFF
--- a/roles/matterbridge/templates/matterbridge.toml
+++ b/roles/matterbridge/templates/matterbridge.toml
@@ -170,6 +170,18 @@ enable=true
     channel="{{ matterbridge_config.rit_foss.slack.channel }}"
 
 [[gateway]]
+name="gateway_rit_lug"
+enable=true
+
+    [[gateway.inout]]
+    account="irc.{{ default_irc_network_name }}"
+    channel="{{ matterbridge_config.rit_lug.irc.channel }}"
+
+    [[gateway.inout]]
+    account="slack.{{ default_slack_team_name }}"
+    channel="{{ matterbridge_config.rit_lug.slack.channel }}"
+
+[[gateway]]
 name="gateway_rit_lug_projects"
 enable=true
 
@@ -194,6 +206,18 @@ enable=true
     channel="{{ matterbridge_config.rit_lug_sysadmin.slack.channel }}"
 
 [[gateway]]
+name="gateway_rit_lug_teleirc"
+enable=true
+
+    [[gateway.inout]]
+    account="irc.{{ default_irc_network_name }}"
+    channel="{{ matterbridge_config.rit_lug_teleirc.irc.channel }}"
+
+    [[gateway.inout]]
+    account="slack.{{ default_slack_team_name }}"
+    channel="{{ matterbridge_config.rit_lug_teleirc.slack.channel }}"
+
+[[gateway]]
 name="gateway_rit_python"
 enable=true
 
@@ -216,35 +240,3 @@ enable=true
     [[gateway.inout]]
     account="slack.{{ default_slack_team_name }}"
     channel="{{ matterbridge_config.rit_tigeros.slack.channel }}"
-
-[[gateway]]
-name="gateway_ritlug"
-enable=true
-
-    [[gateway.inout]]
-    account="irc.{{ default_irc_network_name }}"
-    channel="{{ matterbridge_config.ritlug.irc.channel }}"
-
-    [[gateway.inout]]
-    account="slack.{{ default_slack_team_name }}"
-    channel="{{ matterbridge_config.ritlug.slack.channel }}"
-
-    [[gateway.inout]]
-    account="irc.{{ default_irc_network_name }}"
-    channel="#ritlug"
-
-[[gateway]]
-name="gateway_ritlug_teleirc"
-enable=true
-
-    [[gateway.inout]]
-    account="irc.{{ default_irc_network_name }}"
-    channel="{{ matterbridge_config.ritlug_teleirc.irc.channel }}"
-
-    [[gateway.inout]]
-    account="slack.{{ default_slack_team_name }}"
-    channel="{{ matterbridge_config.ritlug_teleirc.slack.channel }}"
-
-    [[gateway.inout]]
-    account="irc.{{ default_irc_network_name }}"
-    channel="#ritlug-teleirc"

--- a/roles/matterbridge/vars/main.yml
+++ b/roles/matterbridge/vars/main.yml
@@ -26,6 +26,13 @@ matterbridge_config:
     slack:
       channel: foss
 
+  rit_lug:
+    irc:
+      bot_name: mb-ritlug
+      channel: "#rit-lug"
+    slack:
+      channel: general
+
   rit_lug_projects:
     irc:
       bot-name: mb-ritlug-proj
@@ -40,6 +47,13 @@ matterbridge_config:
     slack:
       channel: sysadmin
 
+  rit_lug_teleirc:
+    irc:
+      bot_name: mb-teleirc
+      channel: "#rit-lug-teleirc"
+    slack:
+      channel: teleirc
+
   rit_python:
     irc:
       bot_name: mb-ritpy
@@ -53,17 +67,3 @@ matterbridge_config:
       channel: "#rit-tigeros"
     slack:
       channel: tigeros
-
-  ritlug:
-    irc:
-      bot_name: mb-ritlug
-      channel: "#rit-lug"
-    slack:
-      channel: general
-
-  ritlug_teleirc:
-    irc:
-      bot_name: mb-teleirc
-      channel: "#rit-lug-teleirc"
-    slack:
-      channel: teleirc


### PR DESCRIPTION
This commit retires the deprecated channels by removing the Matterbridge
bot from the old channels. Last week, we successfully migrated the IRC
channels to the RIT-registered namespace on Freenode. The two-way bridge
across two channels will be removed once the playbook runs with this
commit included.

Also, the diff is hard to read because I reorganized the channels
alphabetically to make it easier to maintain this file if it grows over
time. Sorry.