### PR TITLE
Add CODEOWNERS file for automatic review requests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# This is a comment.
+# Each line is a file pattern followed by one or more owners. Order is
+# important; the last matching pattern takes the most precedence.
+
+# These owners will be the default owners for everything in the repo. Unless a
+# later match takes precedence, the default owner is be requested for review
+# when someone opens a pull request.
+*       @FOSSRIT/ansible-maintainers


### PR DESCRIPTION
This commit adds a CODEOWNERS file. It works similar to a `gitignore`,
except it integrates with the GitHub PR review functionality. In this
case, the @FOSSRIT/ansible-maintainers team will always get pinged for
reviews on new pull requests in this repo.