### PR TITLE
matterbridge: Upgrade to v1.17.0 release

### DIFF
--- a/roles/matterbridge/vars/main.yml
+++ b/roles/matterbridge/vars/main.yml
@@ -9,8 +9,8 @@ default_slack_ignore_nicks: ""
 default_slack_team_name: rit-lug
 
 matterbridge_config:
-  binary_checksum: "9ed2b0e31c4ea618dc02f8b55bdef5d9c2a802ffe3de9cf32acd7a00b8d59029"
-  version: 1.16.5
+  binary_checksum: "d60cb4bb503eb5e70cfabeccd8318855c547c2f3b62760cfec5d23db309c8ba7"
+  version: 1.17.0
 
   rit:
     irc:


### PR DESCRIPTION
Matterbridge upstream released a new minor feature release:

https://github.com/42wim/matterbridge/releases/tag/v1.17.0

There are a good number of changes, including support for Microsoft
Teams. (What?!) But the relevant bits of the changelog for us are below:

* general: support JSON and YAML config formats (42wim/matterbridge#1045)
* irc: Be less lossy when throttling IRC messages (42wim/matterbridge#1004)
* slack: Use upstream slack-go/slack again (42wim/matterbridge#1018)
* slack: Ignore ConnectingEvent (42wim/matterbridge#1041)
* slack: use blocks not attachments (42wim/matterbridge#1048)
* slack: Fix 42wim/matterbridge#1039: messages sent to Slack being synced back (42wim/matterbridge#1046)

And a hat tip to our upstream devs who made this release possible:
@qaisjp, @jakubgs, @burner1024, @notpushkin, @MartijnBraam, and @42wim.

This upgrade is currently running in production without issue. This
commit brings the config management up to date with what is currently
running out in prod.