### PR TITLE
ci: Stop alerting in `##jwf` on Freenode IRC

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ jobs:
 notifications:
   irc:
     channels:
-      - "ircs://chat.freenode.net:6697/##jwf"
       - "ircs://chat.freenode.net:6697/#rit-foss-admin"
     template:
       - "[%{repository_name}:%{branch}@%{commit} - build #%{build_number}] CI %{result}! (%{build_url})"


### PR DESCRIPTION
Pretty sure I forgot to delete this line when I copied the Travis config
from another one of my repos. Doesn't make sense to have
FOSSRIT/infrastructure notifications echo in my IRC support channel.