### PR TITLE
matterbridge: Upgrade to v1.17.1

### DIFF
--- a/roles/matterbridge/vars/main.yml
+++ b/roles/matterbridge/vars/main.yml
@@ -9,8 +9,8 @@ default_slack_ignore_nicks: ""
 default_slack_team_name: rit-lug
 
 matterbridge_config:
-  binary_checksum: "d60cb4bb503eb5e70cfabeccd8318855c547c2f3b62760cfec5d23db309c8ba7"
-  version: 1.17.0
+  binary_checksum: "ef47be1f1ff6d8ffeea2b513a768c076c5bdfa849b37ec5ff8ec7e6fa401b76f"
+  version: 1.17.1
 
   rit:
     irc:


### PR DESCRIPTION
New minor release of Matterbridge upstream. None of the changes impact
our usage, but I prefer to remain current on upgrades to avoid to many
changes piling on all at once:

https://github.com/42wim/matterbridge/releases/tag/v1.17.1

At commit time, this change was already run and pushed to production.