### PR TITLE
matterbridge: v1.17.1 -> v1.17.3

### DIFF
--- a/roles/matterbridge/vars/main.yml
+++ b/roles/matterbridge/vars/main.yml
@@ -9,8 +9,8 @@ default_slack_ignore_nicks: ""
 default_slack_team_name: rit-lug
 
 matterbridge_config:
-  binary_checksum: "ef47be1f1ff6d8ffeea2b513a768c076c5bdfa849b37ec5ff8ec7e6fa401b76f"
-  version: 1.17.1
+  binary_checksum: "5cbe22bc9ea4b94c69c923583c77fed7066a4cf19e6df26c0714f5a7511f385d"
+  version: 1.17.3
 
   rit:
     irc:


### PR DESCRIPTION
Periodic version bump. A few upstream changes highlighted that may be
relevant for us:

https://github.com/42wim/matterbridge/releases/tag/v1.17.3

v1.17.3
=======

* irc: Add JoinDelay option (irc). Fixes 42wim/matterbridge#1084
  (42wim/matterbridge#1098)
* slack: Clip too long messages on 3000 length (slack). Fixes
    * This one will definitely affect RIT FOSS for IRC/Matrix/Riot users
      with really long messages to Slack.
  42wim/matterbridge#1081 (42wim/matterbridge#1102)
* slack: Prevent image/message looping (slack). Fixes
  42wim/matterbridge#1088 (42wim/matterbridge#1096)
* irc: Add extra space before colon in attachments (irc). Fixes
  42wim/matterbridge#1089 (42wim/matterbridge#1101)

v1.17.2
=======

* slack: Update vendor slack-go/slack (42wim/matterbridge#1068)