### PR TITLE
Make TeleIRC bridges respect default_branch override

### DIFF
--- a/roles/jwflory.teleirc/tasks/compile.yml
+++ b/roles/jwflory.teleirc/tasks/compile.yml
@@ -9,22 +9,25 @@
 - name: git clone/pull RITlug/teleirc
   git:
     repo: "https://github.com/RITlug/teleirc.git"
-    dest: "/tmp/teleirc"
-    version: "{{ default_version }}"
+    dest: "/tmp/teleirc/{{ item.value.cn }}"
+    version: "{{ item.value.version }}"
     accept_hostkey: yes
     force: yes
+  loop: "{{ bots|dict2items }}"
 
 - name: build teleirc binary
   command:
     cmd: bash build_binary.sh
-    chdir: "/tmp/teleirc/"
+    chdir: "/tmp/teleirc/{{ item.value.cn }}"
+  loop: "{{ bots|dict2items }}"
 
 - name: push teleirc binary to /usr/local/bin
   copy:
     remote_src: true
-    src: "/tmp/teleirc/teleirc"
-    dest: "/usr/local/bin/teleirc"
+    src: "/tmp/teleirc/{{ item.value.cn }}/teleirc"
+    dest: "/usr/local/bin/{{ item.value.cn }}"
     mode: 0755
     setype: bin_t
     seuser: system_u
+  loop: "{{ bots|dict2items }}"
   notify: restart teleirc

--- a/roles/jwflory.teleirc/templates/teleirc.service
+++ b/roles/jwflory.teleirc/templates/teleirc.service
@@ -6,7 +6,7 @@ After=multi-user.target
 [Service]
 Type=simple
 User=teleirc
-ExecStart=/usr/local/bin/teleirc -conf /etc/teleirc/env-{{ item.value.cn }}
+ExecStart=/usr/local/bin/{{ item.value.cn }} -conf /etc/teleirc/env-{{ item.value.cn }}
 Restart=always
 RestartSec=60
 

--- a/roles/jwflory.teleirc/vars/main.yml
+++ b/roles/jwflory.teleirc/vars/main.yml
@@ -61,7 +61,6 @@ bots:
     imgur_client_id: "{{ default_imgur_client_id }}"
     version: HEAD
 
-
   rit_foss:
     cn: "rit-foss"
     irc_blacklist: "CowSayBot"

--- a/roles/jwflory.teleirc/vars/main.yml
+++ b/roles/jwflory.teleirc/vars/main.yml
@@ -59,7 +59,7 @@ bots:
     teleirc_token: "{{ vault_bots.rit.vault_teleirc_token }}"
     teleirc_chat_id: "{{ vault_bots.rit.vault_teleirc_chat_id }}"
     imgur_client_id: "{{ default_imgur_client_id }}"
-    version: HEAD
+    version: "feature/reply"
 
   rit_foss:
     cn: "rit-foss"
@@ -72,7 +72,7 @@ bots:
     teleirc_token: "{{ vault_bots.rit_foss.vault_teleirc_token }}"
     teleirc_chat_id: "{{ vault_bots.rit_foss.vault_teleirc_chat_id }}"
     imgur_client_id: "{{ default_imgur_client_id }}"
-    version: HEAD
+    version: "feature/reply"
 
   rit_foss_admin:
     cn: "rit-foss-admin"
@@ -85,7 +85,7 @@ bots:
     teleirc_token: "{{ vault_bots.rit_foss_admin.vault_teleirc_token }}"
     teleirc_chat_id: "{{ vault_bots.rit_foss_admin.vault_teleirc_chat_id }}"
     imgur_client_id: "{{ default_imgur_client_id }}"
-    version: HEAD
+    version: "feature/reply"
 
   rit_librecorps:
     cn: "rit-librecorps"
@@ -98,7 +98,7 @@ bots:
     teleirc_token: "{{ vault_bots.rit_librecorps.vault_teleirc_token }}"
     teleirc_chat_id: "{{ vault_bots.rit_librecorps.vault_teleirc_chat_id }}"
     imgur_client_id: "{{ default_imgur_client_id }}"
-    version: HEAD
+    version: "feature/reply"
 
   rit_python:
     cn: "rit-python"
@@ -111,7 +111,7 @@ bots:
     teleirc_token: "{{ vault_bots.rit_python.vault_teleirc_token }}"
     teleirc_chat_id: "{{ vault_bots.rit_python.vault_teleirc_chat_id }}"
     imgur_client_id: "{{ default_imgur_client_id }}"
-    version: HEAD
+    version: "feature/reply"
 
   rit_tigeros:
     cn: "rit-tigeros"
@@ -124,7 +124,7 @@ bots:
     teleirc_token: "{{ vault_bots.rit_tigeros.vault_teleirc_token }}"
     teleirc_chat_id: "{{ vault_bots.rit_tigeros.vault_teleirc_chat_id }}"
     imgur_client_id: "{{ default_imgur_client_id }}"
-    version: HEAD
+    version: "feature/reply"
 
   rit_lug:
     cn: "rit-lug"
@@ -137,7 +137,7 @@ bots:
     teleirc_token: "{{ vault_bots.rit_lug.vault_teleirc_token }}"
     teleirc_chat_id: "{{ vault_bots.rit_lug.vault_teleirc_chat_id }}"
     imgur_client_id: "{{ default_imgur_client_id }}"
-    version: HEAD
+    version: "feature/reply"
 
   rit_lug_teleirc:
     cn: "rit-lug-teleirc"
@@ -150,5 +150,5 @@ bots:
     teleirc_token: "{{ vault_bots.rit_lug_teleirc.vault_teleirc_token }}"
     teleirc_chat_id: "{{ vault_bots.rit_lug_teleirc.vault_teleirc_chat_id }}"
     imgur_client_id: "{{ default_imgur_client_id }}"
-    version: HEAD
+    version: "feature/reply"
 

--- a/roles/jwflory.teleirc/vars/main.yml
+++ b/roles/jwflory.teleirc/vars/main.yml
@@ -59,7 +59,8 @@ bots:
     teleirc_token: "{{ vault_bots.rit.vault_teleirc_token }}"
     teleirc_chat_id: "{{ vault_bots.rit.vault_teleirc_chat_id }}"
     imgur_client_id: "{{ default_imgur_client_id }}"
-    version: "feature/reply"
+    version: "{{ default_version }}"
+
 
   rit_foss:
     cn: "rit-foss"
@@ -72,7 +73,7 @@ bots:
     teleirc_token: "{{ vault_bots.rit_foss.vault_teleirc_token }}"
     teleirc_chat_id: "{{ vault_bots.rit_foss.vault_teleirc_chat_id }}"
     imgur_client_id: "{{ default_imgur_client_id }}"
-    version: "feature/reply"
+    version: "{{ default_version }}"
 
   rit_foss_admin:
     cn: "rit-foss-admin"
@@ -85,7 +86,7 @@ bots:
     teleirc_token: "{{ vault_bots.rit_foss_admin.vault_teleirc_token }}"
     teleirc_chat_id: "{{ vault_bots.rit_foss_admin.vault_teleirc_chat_id }}"
     imgur_client_id: "{{ default_imgur_client_id }}"
-    version: "feature/reply"
+    version: "{{ default_version }}"
 
   rit_librecorps:
     cn: "rit-librecorps"
@@ -98,7 +99,7 @@ bots:
     teleirc_token: "{{ vault_bots.rit_librecorps.vault_teleirc_token }}"
     teleirc_chat_id: "{{ vault_bots.rit_librecorps.vault_teleirc_chat_id }}"
     imgur_client_id: "{{ default_imgur_client_id }}"
-    version: "feature/reply"
+    version: "{{ default_version }}"
 
   rit_python:
     cn: "rit-python"
@@ -111,7 +112,7 @@ bots:
     teleirc_token: "{{ vault_bots.rit_python.vault_teleirc_token }}"
     teleirc_chat_id: "{{ vault_bots.rit_python.vault_teleirc_chat_id }}"
     imgur_client_id: "{{ default_imgur_client_id }}"
-    version: "feature/reply"
+    version: "{{ default_version }}"
 
   rit_tigeros:
     cn: "rit-tigeros"
@@ -124,7 +125,7 @@ bots:
     teleirc_token: "{{ vault_bots.rit_tigeros.vault_teleirc_token }}"
     teleirc_chat_id: "{{ vault_bots.rit_tigeros.vault_teleirc_chat_id }}"
     imgur_client_id: "{{ default_imgur_client_id }}"
-    version: "feature/reply"
+    version: "{{ default_version }}"
 
   rit_lug:
     cn: "rit-lug"
@@ -137,7 +138,7 @@ bots:
     teleirc_token: "{{ vault_bots.rit_lug.vault_teleirc_token }}"
     teleirc_chat_id: "{{ vault_bots.rit_lug.vault_teleirc_chat_id }}"
     imgur_client_id: "{{ default_imgur_client_id }}"
-    version: "feature/reply"
+    version: "{{ default_version }}"
 
   rit_lug_teleirc:
     cn: "rit-lug-teleirc"
@@ -150,5 +151,5 @@ bots:
     teleirc_token: "{{ vault_bots.rit_lug_teleirc.vault_teleirc_token }}"
     teleirc_chat_id: "{{ vault_bots.rit_lug_teleirc.vault_teleirc_chat_id }}"
     imgur_client_id: "{{ default_imgur_client_id }}"
-    version: "feature/reply"
+    version: "{{ default_version }}"
 

--- a/roles/jwflory.teleirc/vars/main.yml
+++ b/roles/jwflory.teleirc/vars/main.yml
@@ -59,7 +59,7 @@ bots:
     teleirc_token: "{{ vault_bots.rit.vault_teleirc_token }}"
     teleirc_chat_id: "{{ vault_bots.rit.vault_teleirc_chat_id }}"
     imgur_client_id: "{{ default_imgur_client_id }}"
-    version: "{{ default_version }}"
+    version: HEAD
 
 
   rit_foss:
@@ -73,7 +73,7 @@ bots:
     teleirc_token: "{{ vault_bots.rit_foss.vault_teleirc_token }}"
     teleirc_chat_id: "{{ vault_bots.rit_foss.vault_teleirc_chat_id }}"
     imgur_client_id: "{{ default_imgur_client_id }}"
-    version: "{{ default_version }}"
+    version: HEAD
 
   rit_foss_admin:
     cn: "rit-foss-admin"
@@ -86,7 +86,7 @@ bots:
     teleirc_token: "{{ vault_bots.rit_foss_admin.vault_teleirc_token }}"
     teleirc_chat_id: "{{ vault_bots.rit_foss_admin.vault_teleirc_chat_id }}"
     imgur_client_id: "{{ default_imgur_client_id }}"
-    version: "{{ default_version }}"
+    version: HEAD
 
   rit_librecorps:
     cn: "rit-librecorps"
@@ -99,7 +99,7 @@ bots:
     teleirc_token: "{{ vault_bots.rit_librecorps.vault_teleirc_token }}"
     teleirc_chat_id: "{{ vault_bots.rit_librecorps.vault_teleirc_chat_id }}"
     imgur_client_id: "{{ default_imgur_client_id }}"
-    version: "{{ default_version }}"
+    version: HEAD
 
   rit_python:
     cn: "rit-python"
@@ -112,7 +112,7 @@ bots:
     teleirc_token: "{{ vault_bots.rit_python.vault_teleirc_token }}"
     teleirc_chat_id: "{{ vault_bots.rit_python.vault_teleirc_chat_id }}"
     imgur_client_id: "{{ default_imgur_client_id }}"
-    version: "{{ default_version }}"
+    version: HEAD
 
   rit_tigeros:
     cn: "rit-tigeros"
@@ -125,7 +125,7 @@ bots:
     teleirc_token: "{{ vault_bots.rit_tigeros.vault_teleirc_token }}"
     teleirc_chat_id: "{{ vault_bots.rit_tigeros.vault_teleirc_chat_id }}"
     imgur_client_id: "{{ default_imgur_client_id }}"
-    version: "{{ default_version }}"
+    version: HEAD
 
   rit_lug:
     cn: "rit-lug"
@@ -138,7 +138,7 @@ bots:
     teleirc_token: "{{ vault_bots.rit_lug.vault_teleirc_token }}"
     teleirc_chat_id: "{{ vault_bots.rit_lug.vault_teleirc_chat_id }}"
     imgur_client_id: "{{ default_imgur_client_id }}"
-    version: "{{ default_version }}"
+    version: HEAD
 
   rit_lug_teleirc:
     cn: "rit-lug-teleirc"
@@ -151,5 +151,5 @@ bots:
     teleirc_token: "{{ vault_bots.rit_lug_teleirc.vault_teleirc_token }}"
     teleirc_chat_id: "{{ vault_bots.rit_lug_teleirc.vault_teleirc_chat_id }}"
     imgur_client_id: "{{ default_imgur_client_id }}"
-    version: "{{ default_version }}"
+    version: HEAD
 


### PR DESCRIPTION
TeleIRC bridges running the Go deployment previously only built a single Go binary running the `{{ default_branch }}`. 
This PR updates that to build each repository individually and starts each project with their respective built binary.



closes #99 